### PR TITLE
feat: AI 예측 데이터 적재 어드민 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.16.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-hot-toast": "^2.6.0",
     "react-router": "^7.13.1",
     "recharts": "^3.8.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,15 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
-      axios:
-        specifier: ^1.16.1
-        version: 1.16.1
       react:
         specifier: ^19.2.4
         version: 19.2.4
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-hot-toast:
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-router:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -716,10 +716,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
-
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -746,12 +742,6 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -775,10 +765,6 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -824,10 +810,6 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -918,20 +900,12 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
-
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
 
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
@@ -956,22 +930,6 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
-
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
 
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
@@ -1086,26 +1044,10 @@ packages:
   flatted@3.4.1:
     resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1119,14 +1061,6 @@ packages:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
-
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -1139,9 +1073,10 @@ packages:
     resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
     engines: {node: '>=18'}
 
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
+  goober@2.1.19:
+    resolution: {integrity: sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==}
+    peerDependencies:
+      csstype: ^3.0.10
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1154,18 +1089,6 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
-    engines: {node: '>= 0.4'}
-
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
@@ -1174,10 +1097,6 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
-
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -1447,18 +1366,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
-
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -1563,10 +1470,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1575,6 +1478,13 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-hot-toast@2.6.0:
+    resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-is@19.2.6:
     resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
@@ -2542,12 +2452,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -2571,18 +2475,6 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  asynckit@0.4.0: {}
-
-  axios@1.16.1:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -2605,11 +2497,6 @@ snapshots:
       electron-to-chromium: 1.5.313
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
 
   callsites@3.1.0: {}
 
@@ -2648,10 +2535,6 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@2.0.20: {}
-
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
 
   commander@14.0.3: {}
 
@@ -2724,20 +2607,12 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  delayed-stream@1.0.0: {}
-
   detect-libc@2.1.2: {}
 
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
-
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
 
   electron-to-chromium@1.5.313: {}
 
@@ -2757,21 +2632,6 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
-
-  es-define-property@1.0.1: {}
-
-  es-errors@1.3.0: {}
-
-  es-object-atoms@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.3
 
   es-toolkit@1.46.1: {}
 
@@ -2898,44 +2758,14 @@ snapshots:
 
   flatted@3.4.1: {}
 
-  follow-redirects@1.16.0: {}
-
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
-      mime-types: 2.1.35
-
   fsevents@2.3.3:
     optional: true
-
-  function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
-
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.3
-      math-intrinsics: 1.1.0
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
 
   glob-parent@6.0.2:
     dependencies:
@@ -2945,23 +2775,15 @@ snapshots:
 
   globals@17.4.0: {}
 
-  gopd@1.2.0: {}
+  goober@2.1.19(csstype@3.2.3):
+    dependencies:
+      csstype: 3.2.3
 
   graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
 
   has-flag@4.0.0: {}
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
-  hasown@2.0.3:
-    dependencies:
-      function-bind: 1.1.2
 
   headers-polyfill@4.0.3: {}
 
@@ -2970,13 +2792,6 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   husky@9.1.7: {}
 
@@ -3188,14 +3003,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  math-intrinsics@1.1.0: {}
-
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
-
   mimic-function@5.0.1: {}
 
   minimatch@10.2.4:
@@ -3302,14 +3109,19 @@ snapshots:
 
   prettier@3.8.1: {}
 
-  proxy-from-env@2.1.0: {}
-
   punycode@2.3.1: {}
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-hot-toast@2.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      csstype: 3.2.3
+      goober: 2.1.19(csstype@3.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-is@19.2.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
+      axios:
+        specifier: ^1.16.1
+        version: 1.16.1
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -716,6 +719,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -742,6 +749,12 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -765,6 +778,10 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -810,6 +827,10 @@ packages:
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -900,12 +921,20 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
 
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
@@ -930,6 +959,22 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
@@ -1044,10 +1089,26 @@ packages:
   flatted@3.4.1:
     resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1060,6 +1121,14 @@ packages:
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1078,6 +1147,10 @@ packages:
     peerDependencies:
       csstype: ^3.0.10
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1089,6 +1162,18 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
@@ -1097,6 +1182,10 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -1366,6 +1455,18 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -1469,6 +1570,10 @@ packages:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2452,6 +2557,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -2475,6 +2586,18 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
+  axios@1.16.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -2497,6 +2620,11 @@ snapshots:
       electron-to-chromium: 1.5.313
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   callsites@3.1.0: {}
 
@@ -2535,6 +2663,10 @@ snapshots:
   color-name@1.1.4: {}
 
   colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   commander@14.0.3: {}
 
@@ -2607,12 +2739,20 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  delayed-stream@1.0.0: {}
+
   detect-libc@2.1.2: {}
 
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   electron-to-chromium@1.5.313: {}
 
@@ -2632,6 +2772,21 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   es-toolkit@1.46.1: {}
 
@@ -2758,14 +2913,44 @@ snapshots:
 
   flatted@3.4.1: {}
 
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   glob-parent@6.0.2:
     dependencies:
@@ -2779,11 +2964,23 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
 
   headers-polyfill@4.0.3: {}
 
@@ -2792,6 +2989,13 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 
@@ -3003,6 +3207,14 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   mimic-function@5.0.1: {}
 
   minimatch@10.2.4:
@@ -3108,6 +3320,8 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
 import { Routes, Route, useLocation } from 'react-router'
+import { Toaster } from 'react-hot-toast'
 import { RootLayout } from '@/app/layouts/RootLayout'
 import { PlayerSearchPage } from '@/pages/player-search'
 import { PlayerDetailPage } from '@/pages/player-detail'
+import { AdminPage } from '@/pages/admin'
 import { MainPage } from './pages/main/ui/MainPage'
 import { useEffect } from 'react'
 
@@ -19,12 +21,33 @@ function App() {
   return (
     <div className="min-h-screen bg-page">
       <ScrollToTop />
+      <Toaster
+        position="top-center"
+        toastOptions={{
+          style: {
+            background: '#1a2535',
+            color: '#e2e8f0',
+            border: '1px solid #1a2235',
+            fontSize: '14px',
+            maxWidth: '420px',
+          },
+          success: {
+            duration: 3500,
+            iconTheme: { primary: '#00c785', secondary: '#1a2535' },
+          },
+          error: {
+            duration: 6000,
+            iconTheme: { primary: '#f87171', secondary: '#1a2535' },
+          },
+        }}
+      />
       <Routes>
         <Route element={<RootLayout />}>
           <Route path="/" element={<MainPage />} />
           <Route path="/search" element={<PlayerSearchPage />} />
           <Route path="/player/:id" element={<PlayerDetailPage />} />
         </Route>
+        <Route path="/admin" element={<AdminPage />} />
       </Routes>
     </div>
   )

--- a/src/entities/prediction-batch/api/useTriggerPrediction.ts
+++ b/src/entities/prediction-batch/api/useTriggerPrediction.ts
@@ -1,0 +1,44 @@
+import { useMutation } from '@tanstack/react-query'
+import type { TopLeagueKey } from '@/shared/lib/league'
+import { getAdminToken, ADMIN_TOKEN_HEADER } from '@/shared/lib/adminToken'
+
+interface TriggerParams {
+  stepPath: string
+  destinationLeague: TopLeagueKey
+}
+
+async function triggerPrediction({
+  stepPath,
+  destinationLeague,
+}: TriggerParams) {
+  const token = getAdminToken()
+  if (!token) {
+    throw new Error('관리자 토큰이 없습니다. 다시 로그인하세요.')
+  }
+
+  const res = await fetch(`/admin/api/predictions/${stepPath}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      [ADMIN_TOKEN_HEADER]: token,
+    },
+    body: JSON.stringify({ destinationLeague }),
+  })
+
+  if (res.status === 202) return
+
+  if (res.status === 401 || res.status === 403) {
+    throw new Error('인증에 실패했습니다. 관리자 토큰을 확인하세요.')
+  }
+  if (res.status === 400) {
+    throw new Error('잘못된 요청입니다. 리그 선택을 확인하세요.')
+  }
+  if (res.status >= 500) {
+    throw new Error('서버 오류로 적재 요청에 실패했습니다.')
+  }
+  throw new Error(`적재 요청 실패 (HTTP ${res.status})`)
+}
+
+export function useTriggerPrediction() {
+  return useMutation({ mutationFn: triggerPrediction })
+}

--- a/src/entities/prediction-batch/api/useTriggerPrediction.ts
+++ b/src/entities/prediction-batch/api/useTriggerPrediction.ts
@@ -1,4 +1,6 @@
 import { useMutation } from '@tanstack/react-query'
+import axios from 'axios'
+import api from '@/shared/api/axios'
 import type { TopLeagueKey } from '@/shared/lib/league'
 import { getAdminToken, ADMIN_TOKEN_HEADER } from '@/shared/lib/adminToken'
 
@@ -16,27 +18,30 @@ async function triggerPrediction({
     throw new Error('관리자 토큰이 없습니다. 다시 로그인하세요.')
   }
 
-  const res = await fetch(`/admin/api/predictions/${stepPath}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      [ADMIN_TOKEN_HEADER]: token,
-    },
-    body: JSON.stringify({ destinationLeague }),
-  })
-
-  if (res.status === 202) return
-
-  if (res.status === 401 || res.status === 403) {
-    throw new Error('인증에 실패했습니다. 관리자 토큰을 확인하세요.')
+  try {
+    await api.post(
+      `/admin/api/predictions/${stepPath}`,
+      { destinationLeague },
+      { headers: { [ADMIN_TOKEN_HEADER]: token } },
+    )
+  } catch (err) {
+    if (!axios.isAxiosError(err)) {
+      throw new Error('적재 요청에 실패했습니다.')
+    }
+    const status = err.response?.status
+    if (status === 403) {
+      throw new Error('인증에 실패했습니다. 관리자 토큰을 확인하세요.')
+    }
+    if (status === 400) {
+      throw new Error('잘못된 요청입니다. 리그 선택을 확인하세요.')
+    }
+    if (status && status >= 500) {
+      throw new Error('서버 오류로 적재 요청에 실패했습니다.')
+    }
+    throw new Error(
+      status ? `적재 요청 실패 (HTTP ${status})` : '적재 요청에 실패했습니다.',
+    )
   }
-  if (res.status === 400) {
-    throw new Error('잘못된 요청입니다. 리그 선택을 확인하세요.')
-  }
-  if (res.status >= 500) {
-    throw new Error('서버 오류로 적재 요청에 실패했습니다.')
-  }
-  throw new Error(`적재 요청 실패 (HTTP ${res.status})`)
 }
 
 export function useTriggerPrediction() {

--- a/src/entities/prediction-batch/api/useVerifyAdminToken.ts
+++ b/src/entities/prediction-batch/api/useVerifyAdminToken.ts
@@ -1,16 +1,17 @@
 import { useMutation } from '@tanstack/react-query'
+import axios from 'axios'
+import api from '@/shared/api/axios'
 
 async function verifyAdminToken(token: string): Promise<boolean> {
-  const res = await fetch('/admin/api/auth/verify', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ adminToken: token }),
-  })
-
-  if (res.status === 200) return true
-  if (res.status === 401 || res.status === 403) return false
-
-  throw new Error('인증 서버에 연결할 수 없습니다. 잠시 후 다시 시도하세요.')
+  try {
+    await api.post('/admin/api/auth/verify', { adminToken: token })
+    return true
+  } catch (err) {
+    if (axios.isAxiosError(err) && err.response?.status === 403) {
+      return false
+    }
+    throw new Error('인증 서버에 연결할 수 없습니다. 잠시 후 다시 시도하세요.')
+  }
 }
 
 export function useVerifyAdminToken() {

--- a/src/entities/prediction-batch/api/useVerifyAdminToken.ts
+++ b/src/entities/prediction-batch/api/useVerifyAdminToken.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query'
+
+async function verifyAdminToken(token: string): Promise<boolean> {
+  const res = await fetch('/admin/api/auth/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ adminToken: token }),
+  })
+
+  if (res.status === 200) return true
+  if (res.status === 401 || res.status === 403) return false
+
+  throw new Error('인증 서버에 연결할 수 없습니다. 잠시 후 다시 시도하세요.')
+}
+
+export function useVerifyAdminToken() {
+  return useMutation({ mutationFn: verifyAdminToken })
+}

--- a/src/entities/prediction-batch/index.ts
+++ b/src/entities/prediction-batch/index.ts
@@ -1,0 +1,2 @@
+export { useTriggerPrediction } from './api/useTriggerPrediction'
+export { useVerifyAdminToken } from './api/useVerifyAdminToken'

--- a/src/features/admin-prediction/index.ts
+++ b/src/features/admin-prediction/index.ts
@@ -1,0 +1,5 @@
+export { default as AdminGate } from './ui/AdminGate'
+export { default as PredictionBatchPanel } from './ui/PredictionBatchPanel'
+export { default as ExecutionHistory } from './ui/ExecutionHistory'
+export { useExecutionHistory } from './lib/useExecutionHistory'
+export type { ExecutionLogEntry } from './model/types'

--- a/src/features/admin-prediction/lib/useExecutionHistory.ts
+++ b/src/features/admin-prediction/lib/useExecutionHistory.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  EXECUTION_HISTORY_STORAGE_KEY,
+  MAX_HISTORY_ENTRIES,
+} from '../model/constants'
+import type { ExecutionLogEntry } from '../model/types'
+
+function readHistory(): ExecutionLogEntry[] {
+  try {
+    const raw = localStorage.getItem(EXECUTION_HISTORY_STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as ExecutionLogEntry[]) : []
+  } catch {
+    return []
+  }
+}
+
+function writeHistory(entries: ExecutionLogEntry[]): void {
+  try {
+    localStorage.setItem(EXECUTION_HISTORY_STORAGE_KEY, JSON.stringify(entries))
+  } catch {
+    /* localStorage 비활성 환경 무시 */
+  }
+}
+
+export function useExecutionHistory() {
+  const [entries, setEntries] = useState<ExecutionLogEntry[]>(readHistory)
+
+  useEffect(() => {
+    writeHistory(entries)
+  }, [entries])
+
+  const append = useCallback(
+    (entry: Omit<ExecutionLogEntry, 'id' | 'triggeredAt'>) => {
+      setEntries((prev) =>
+        [
+          {
+            ...entry,
+            id:
+              typeof crypto !== 'undefined' && crypto.randomUUID
+                ? crypto.randomUUID()
+                : String(Date.now()),
+            triggeredAt: Date.now(),
+          },
+          ...prev,
+        ].slice(0, MAX_HISTORY_ENTRIES),
+      )
+    },
+    [],
+  )
+
+  const clear = useCallback(() => setEntries([]), [])
+
+  return { entries, append, clear }
+}

--- a/src/features/admin-prediction/model/constants.ts
+++ b/src/features/admin-prediction/model/constants.ts
@@ -1,0 +1,36 @@
+import type { PredictionStepDef } from './types'
+
+export const PIPELINE_STEP: PredictionStepDef = {
+  key: 'pipeline',
+  path: 'pipeline',
+  label: '전체 파이프라인',
+  failurePolicy: '한 단계라도 실패하면 이후 단계 없이 전체가 즉시 중단됩니다.',
+  kind: 'pipeline',
+}
+
+export const INDIVIDUAL_STEPS: PredictionStepDef[] = [
+  {
+    key: 'performance',
+    path: 'performance',
+    label: '퍼포먼스 예측',
+    failurePolicy: '실패한 청크는 건너뛰고 나머지 선수는 계속 적재합니다.',
+    kind: 'step',
+  },
+  {
+    key: 'market-value',
+    path: 'market-value',
+    label: '시장가치 예측',
+    failurePolicy: '실패한 청크는 건너뛰고 나머지 선수는 계속 적재합니다.',
+    kind: 'step',
+  },
+  {
+    key: 'similar-players',
+    path: 'similar-players',
+    label: '유사 선수 추천',
+    failurePolicy: '실패한 청크는 건너뛰고 나머지 선수는 계속 적재합니다.',
+    kind: 'step',
+  },
+]
+
+export const EXECUTION_HISTORY_STORAGE_KEY = 'admin:prediction-history'
+export const MAX_HISTORY_ENTRIES = 50

--- a/src/features/admin-prediction/model/types.ts
+++ b/src/features/admin-prediction/model/types.ts
@@ -1,0 +1,24 @@
+import type { TopLeagueKey } from '@/shared/lib/league'
+
+export type PredictionStepKey =
+  | 'pipeline'
+  | 'performance'
+  | 'market-value'
+  | 'similar-players'
+
+export interface PredictionStepDef {
+  key: PredictionStepKey
+  path: string
+  label: string
+  failurePolicy: string
+  kind: 'pipeline' | 'step'
+}
+
+export interface ExecutionLogEntry {
+  id: string
+  stepKey: PredictionStepKey
+  stepLabel: string
+  leagueKey: TopLeagueKey
+  leagueLabel: string
+  triggeredAt: number
+}

--- a/src/features/admin-prediction/ui/AdminGate.tsx
+++ b/src/features/admin-prediction/ui/AdminGate.tsx
@@ -1,0 +1,87 @@
+import { useState, type FormEvent } from 'react'
+import { useVerifyAdminToken } from '@/entities/prediction-batch'
+
+interface AdminGateProps {
+  onSubmit: (token: string) => void
+}
+
+export default function AdminGate({ onSubmit }: AdminGateProps) {
+  const [value, setValue] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const { mutateAsync, isPending } = useVerifyAdminToken()
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    const token = value.trim()
+    if (!token) {
+      setError('토큰을 입력하세요.')
+      return
+    }
+    setError(null)
+    try {
+      const valid = await mutateAsync(token)
+      if (valid) {
+        onSubmit(token)
+      } else {
+        setError('유효하지 않은 토큰입니다.')
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : '인증에 실패했습니다. 다시 시도하세요.',
+      )
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-page flex items-center justify-center px-6">
+      <div className="w-full max-w-sm">
+        <div className="mb-6 text-center">
+          <span className="text-xl font-bold tracking-tight text-white">
+            Footure
+            <span className="ml-2 align-middle text-[11px] font-semibold text-brand bg-brand/10 border border-brand/40 rounded px-1.5 py-0.5">
+              ADMIN
+            </span>
+          </span>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="rounded-2xl bg-card ring-1 ring-border p-7"
+        >
+          <h1 className="text-xl font-bold text-white">관리자 인증</h1>
+          <p className="mt-2 text-sm text-text-gray leading-relaxed">
+            예측 데이터 적재 콘솔에 접근하려면
+            <br />
+            관리자 토큰이 필요합니다.
+          </p>
+
+          <input
+            type="password"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value)
+              if (error) setError(null)
+            }}
+            placeholder="관리자 토큰"
+            autoFocus
+            disabled={isPending}
+            className={`mt-6 w-full rounded-xl bg-input px-4 py-3.5 text-sm text-white placeholder:text-gray-600 outline-none ring-1 transition-colors disabled:opacity-60 ${
+              error ? 'ring-red-500/60' : 'ring-border focus:ring-brand'
+            }`}
+          />
+          {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={isPending}
+            className="mt-4 w-full rounded-xl bg-brand hover:bg-brand-hover text-black font-semibold text-base py-3.5 transition-colors disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer"
+          >
+            {isPending ? '확인 중' : '입장'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/features/admin-prediction/ui/ExecutionHistory.tsx
+++ b/src/features/admin-prediction/ui/ExecutionHistory.tsx
@@ -1,0 +1,62 @@
+import type { ExecutionLogEntry } from '../model/types'
+
+interface ExecutionHistoryProps {
+  entries: ExecutionLogEntry[]
+  onClear: () => void
+}
+
+function formatRelative(ts: number): string {
+  const diff = Date.now() - ts
+  const min = Math.floor(diff / 60000)
+  if (min < 1) return '방금 전'
+  if (min < 60) return `${min}분 전`
+  const hour = Math.floor(min / 60)
+  if (hour < 24) return `${hour}시간 전`
+  return `${Math.floor(hour / 24)}일 전`
+}
+
+export default function ExecutionHistory({
+  entries,
+  onClear,
+}: ExecutionHistoryProps) {
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-white">실행 내역</p>
+        {entries.length > 0 && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-xs text-text-gray hover:text-gray-300 transition-colors cursor-pointer"
+          >
+            전체 삭제
+          </button>
+        )}
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="mt-6 text-sm text-text-gray">실행 내역이 없습니다.</p>
+      ) : (
+        <ul className="mt-4 space-y-2">
+          {entries.map((entry) => (
+            <li
+              key={entry.id}
+              className="rounded-xl ring-1 ring-border bg-button/70 px-3.5 py-3"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-medium text-white truncate">
+                  {entry.leagueLabel}
+                  <span className="text-gray-600"> · </span>
+                  {entry.stepLabel}
+                </span>
+                <span className="shrink-0 text-xs text-text-gray">
+                  {formatRelative(entry.triggeredAt)}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/features/admin-prediction/ui/PredictionBatchPanel.tsx
+++ b/src/features/admin-prediction/ui/PredictionBatchPanel.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react'
+import toast from 'react-hot-toast'
+import ConfirmDialog from '@/shared/ui/ConfirmDialog'
+import { TOP_LEAGUE_TABS, type TopLeagueKey } from '@/shared/lib/league'
+import { useTriggerPrediction } from '@/entities/prediction-batch'
+import { PIPELINE_STEP, INDIVIDUAL_STEPS } from '../model/constants'
+import type { ExecutionLogEntry, PredictionStepDef } from '../model/types'
+
+interface PredictionBatchPanelProps {
+  onTriggered: (entry: Omit<ExecutionLogEntry, 'id' | 'triggeredAt'>) => void
+}
+
+export default function PredictionBatchPanel({
+  onTriggered,
+}: PredictionBatchPanelProps) {
+  const [leagueKey, setLeagueKey] = useState<TopLeagueKey | null>(null)
+  const [pending, setPending] = useState<PredictionStepDef | null>(null)
+  const { mutate, isPending } = useTriggerPrediction()
+
+  const selectedLeague = TOP_LEAGUE_TABS.find((l) => l.key === leagueKey)
+  const disabled = !leagueKey || isPending
+
+  const handleConfirm = () => {
+    if (!pending || !leagueKey || !selectedLeague) return
+    const step = pending
+    mutate(
+      { stepPath: step.path, destinationLeague: leagueKey },
+      {
+        onSuccess: () => {
+          onTriggered({
+            stepKey: step.key,
+            stepLabel: step.label,
+            leagueKey,
+            leagueLabel: selectedLeague.label,
+          })
+          toast.success(
+            `${selectedLeague.label} · ${step.label} 적재를 요청했습니다.`,
+          )
+          setPending(null)
+        },
+        onError: (err) => {
+          toast.error(
+            err instanceof Error ? err.message : '적재 요청에 실패했습니다.',
+          )
+          setPending(null)
+        },
+      },
+    )
+  }
+
+  return (
+    <div>
+      <p className="text-sm font-medium text-white">이적 목적지 리그</p>
+      <p className="mt-1 text-xs text-text-gray">
+        적재할 대상 리그를 선택합니다.
+      </p>
+      <div className="mt-4 grid grid-cols-3 sm:grid-cols-5 gap-2">
+        {TOP_LEAGUE_TABS.map((league) => {
+          const active = leagueKey === league.key
+          return (
+            <button
+              key={league.key}
+              type="button"
+              onClick={() => setLeagueKey(league.key)}
+              className={`flex min-w-0 items-center justify-center gap-1.5 rounded-lg px-2 py-2.5 text-xs font-medium transition-all duration-150 cursor-pointer ring-1 ${
+                active
+                  ? 'ring-brand bg-emerald-500/10 text-emerald-400'
+                  : 'ring-border bg-button/80 text-gray-400 hover:text-gray-200'
+              }`}
+            >
+              <img
+                src={league.flag}
+                alt=""
+                className="h-3.5 w-5 shrink-0 rounded-xs object-cover"
+              />
+              <span className="truncate">{league.label}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      <div
+        className="mt-6 rounded-2xl p-5"
+        style={{
+          background:
+            'linear-gradient(to bottom right, rgba(0,199,133,0.094), rgba(0,199,133,0.03))',
+          border: '1px solid rgba(0,199,133,0.19)',
+        }}
+      >
+        <p className="text-sm font-semibold text-white">전체 파이프라인 적재</p>
+        <p className="mt-1 text-xs text-text-gray leading-relaxed">
+          퍼포먼스 → 시장가치 → 유사 선수 순으로 실행됩니다.
+          <br />한 단계라도 실패하면 즉시 중단됩니다.
+        </p>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => setPending(PIPELINE_STEP)}
+          className="mt-4 w-full rounded-xl bg-brand hover:bg-brand-hover text-black font-semibold text-sm py-3.5 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer transition-colors"
+        >
+          전체 파이프라인 실행
+        </button>
+      </div>
+
+      <div className="my-6 h-px bg-linear-to-r from-transparent via-gray-700 to-transparent" />
+
+      <p className="text-sm font-medium text-white">개별 단계 실행</p>
+      <p className="mt-1 text-xs text-text-gray">
+        실패한 청크는 건너뛰고 계속 진행합니다.
+      </p>
+      <div className="mt-4 grid grid-cols-3 gap-2">
+        {INDIVIDUAL_STEPS.map((step) => (
+          <button
+            key={step.key}
+            type="button"
+            disabled={disabled}
+            onClick={() => setPending(step)}
+            className="rounded-xl ring-1 ring-border bg-button/70 text-gray-300 text-xs font-medium py-3 hover:ring-brand hover:bg-emerald-500/10 hover:text-emerald-400 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:ring-border disabled:hover:bg-button/70 disabled:hover:text-gray-300 cursor-pointer transition-all duration-150"
+          >
+            {step.label}
+          </button>
+        ))}
+      </div>
+
+      {!leagueKey && (
+        <p className="mt-5 text-center text-xs text-text-gray">
+          먼저 리그를 선택하세요.
+        </p>
+      )}
+
+      <ConfirmDialog
+        open={pending !== null}
+        title={
+          pending && selectedLeague
+            ? `${selectedLeague.label} · ${pending.label}`
+            : ''
+        }
+        description="기존 예측 데이터를 덮어쓰며 되돌릴 수 없습니다."
+        confirmText="적재 실행"
+        loading={isPending}
+        onConfirm={handleConfirm}
+        onCancel={() => !isPending && setPending(null)}
+      />
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -25,3 +25,24 @@
     }
   }
 }
+
+@layer utilities {
+  .custom-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.22) transparent;
+  }
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background-color: rgba(148, 163, 184, 0.22);
+    border-radius: 9999px;
+  }
+  .custom-scrollbar:hover::-webkit-scrollbar-thumb {
+    background-color: rgba(148, 163, 184, 0.4);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,10 +4,19 @@ import { Providers } from '@/app/providers'
 import './index.css'
 import App from './App.tsx'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <Providers>
-      <App />
-    </Providers>
-  </StrictMode>,
-)
+async function enableMocking() {
+  if (import.meta.env.DEV) {
+    const { worker } = await import('./mocks/browser')
+    return worker.start({ onUnhandledRequest: 'bypass' })
+  }
+}
+
+enableMocking().then(() => {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <Providers>
+        <App />
+      </Providers>
+    </StrictMode>,
+  )
+})

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser'
+import { handlers } from './handlers'
+
+export const worker = setupWorker(...handlers)

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,3 @@
+import { adminPredictionHandlers } from './handlers/adminPrediction'
+
+export const handlers = [...adminPredictionHandlers]

--- a/src/mocks/handlers/adminPrediction.ts
+++ b/src/mocks/handlers/adminPrediction.ts
@@ -11,6 +11,15 @@ const VALID_LEAGUES = ['EPL', 'LA', 'BL', 'SA', 'L1']
 
 const MOCK_ADMIN_TOKEN = 'mockadmin'
 
+const forbiddenAdminTokenResponse = () =>
+  HttpResponse.json(
+    {
+      code: 'FORBIDDEN_ADMIN_TOKEN',
+      message: '어드민 토큰이 유효하지 않습니다.',
+    },
+    { status: 403 },
+  )
+
 const adminVerifyHandler = http.post(
   '/admin/api/auth/verify',
   async ({ request }) => {
@@ -19,10 +28,7 @@ const adminVerifyHandler = http.post(
       adminToken?: string
     } | null
     if (!body?.adminToken || body.adminToken !== MOCK_ADMIN_TOKEN) {
-      return HttpResponse.json(
-        { code: 'UNAUTHORIZED', message: '유효하지 않은 어드민 토큰입니다.' },
-        { status: 401 },
-      )
+      return forbiddenAdminTokenResponse()
     }
     return new HttpResponse(null, { status: 200 })
   },
@@ -34,13 +40,7 @@ const predictionStepHandlers = STEPS.map((step) =>
 
     const token = request.headers.get('X-ADMIN-TOKEN')
     if (!token || token !== MOCK_ADMIN_TOKEN) {
-      return HttpResponse.json(
-        {
-          code: 'UNAUTHORIZED',
-          message: '유효하지 않은 어드민 토큰입니다.',
-        },
-        { status: 401 },
-      )
+      return forbiddenAdminTokenResponse()
     }
 
     const body = (await request.json().catch(() => null)) as {

--- a/src/mocks/handlers/adminPrediction.ts
+++ b/src/mocks/handlers/adminPrediction.ts
@@ -1,0 +1,66 @@
+import { http, HttpResponse, delay } from 'msw'
+
+const STEPS = [
+  'pipeline',
+  'performance',
+  'market-value',
+  'similar-players',
+] as const
+
+const VALID_LEAGUES = ['EPL', 'LA', 'BL', 'SA', 'L1']
+
+const MOCK_ADMIN_TOKEN = 'mockadmin'
+
+const adminVerifyHandler = http.post(
+  '/admin/api/auth/verify',
+  async ({ request }) => {
+    await delay(300)
+    const body = (await request.json().catch(() => null)) as {
+      adminToken?: string
+    } | null
+    if (!body?.adminToken || body.adminToken !== MOCK_ADMIN_TOKEN) {
+      return HttpResponse.json(
+        { code: 'UNAUTHORIZED', message: '유효하지 않은 어드민 토큰입니다.' },
+        { status: 401 },
+      )
+    }
+    return new HttpResponse(null, { status: 200 })
+  },
+)
+
+const predictionStepHandlers = STEPS.map((step) =>
+  http.post(`/admin/api/predictions/${step}`, async ({ request }) => {
+    await delay(400)
+
+    const token = request.headers.get('X-ADMIN-TOKEN')
+    if (!token || token !== MOCK_ADMIN_TOKEN) {
+      return HttpResponse.json(
+        {
+          code: 'UNAUTHORIZED',
+          message: '유효하지 않은 어드민 토큰입니다.',
+        },
+        { status: 401 },
+      )
+    }
+
+    const body = (await request.json().catch(() => null)) as {
+      destinationLeague?: string
+    } | null
+    if (
+      !body?.destinationLeague ||
+      !VALID_LEAGUES.includes(body.destinationLeague)
+    ) {
+      return HttpResponse.json(
+        { code: 'INVALID_LEAGUE', message: '허용 값: EPL, LA, BL, SA, L1' },
+        { status: 400 },
+      )
+    }
+
+    return new HttpResponse(null, { status: 202 })
+  }),
+)
+
+export const adminPredictionHandlers = [
+  adminVerifyHandler,
+  ...predictionStepHandlers,
+]

--- a/src/pages/admin/index.ts
+++ b/src/pages/admin/index.ts
@@ -1,0 +1,1 @@
+export { AdminPage } from './ui/AdminPage'

--- a/src/pages/admin/ui/AdminPage.tsx
+++ b/src/pages/admin/ui/AdminPage.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import {
+  AdminGate,
+  PredictionBatchPanel,
+  ExecutionHistory,
+  useExecutionHistory,
+} from '@/features/admin-prediction'
+import {
+  getAdminToken,
+  setAdminToken,
+  clearAdminToken,
+} from '@/shared/lib/adminToken'
+
+export function AdminPage() {
+  const [token, setToken] = useState<string | null>(getAdminToken)
+  const { entries, append, clear } = useExecutionHistory()
+
+  const handleAuth = (next: string) => {
+    setAdminToken(next)
+    setToken(next)
+  }
+
+  const handleLogout = () => {
+    clearAdminToken()
+    setToken(null)
+  }
+
+  if (!token) {
+    return <AdminGate onSubmit={handleAuth} />
+  }
+
+  return (
+    <div className="min-h-screen bg-page text-white">
+      <header className="border-b border-line/12">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-8 py-5">
+          <span className="text-base font-bold tracking-tight text-white">
+            Footure
+            <span className="ml-2 align-middle text-[11px] font-semibold text-brand bg-brand/10 border border-brand/40 rounded px-1.5 py-0.5">
+              ADMIN
+            </span>
+          </span>
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="text-sm text-gray-400 hover:text-white transition-colors cursor-pointer"
+          >
+            로그아웃
+          </button>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-5xl px-8 py-12">
+        <div className="inline-flex items-center gap-2 rounded-full border border-brand bg-brand/10 px-3 py-1 text-xs font-medium text-brand">
+          <span className="h-1.5 w-1.5 rounded-full bg-brand" />
+          관리자 콘솔
+        </div>
+        <h1 className="mt-4 text-3xl font-bold tracking-tight">
+          예측 데이터 적재
+        </h1>
+        <p className="mt-2 text-sm text-text-gray leading-relaxed">
+          적재는 백그라운드에서 비동기로 처리됩니다. 진행 상태는 제공되지
+          않으며, 결과는 서비스 화면에서 확인할 수 있습니다.
+        </p>
+
+        <div className="mt-10 grid gap-6 lg:grid-cols-[1fr_360px] lg:items-stretch">
+          <section className="rounded-2xl bg-card ring-1 ring-border p-8">
+            <PredictionBatchPanel onTriggered={append} />
+          </section>
+
+          <aside className="lg:relative">
+            <div className="custom-scrollbar rounded-2xl bg-card ring-1 ring-border p-6 lg:absolute lg:inset-0 lg:overflow-y-auto">
+              <ExecutionHistory entries={entries} onClear={clear} />
+            </div>
+          </aside>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/shared/lib/adminToken.ts
+++ b/src/shared/lib/adminToken.ts
@@ -1,0 +1,27 @@
+const ADMIN_TOKEN_STORAGE_KEY = 'admin:x-admin-token'
+
+export const ADMIN_TOKEN_HEADER = 'X-ADMIN-TOKEN'
+
+export function getAdminToken(): string | null {
+  try {
+    return sessionStorage.getItem(ADMIN_TOKEN_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+export function setAdminToken(token: string): void {
+  try {
+    sessionStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, token)
+  } catch {
+    /* sessionStorage 비활성 환경 무시 */
+  }
+}
+
+export function clearAdminToken(): void {
+  try {
+    sessionStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY)
+  } catch {
+    /* noop */
+  }
+}

--- a/src/shared/ui/ConfirmDialog.tsx
+++ b/src/shared/ui/ConfirmDialog.tsx
@@ -1,0 +1,81 @@
+import { useEffect } from 'react'
+
+interface ConfirmDialogProps {
+  open: boolean
+  title: string
+  description?: React.ReactNode
+  confirmText?: string
+  cancelText?: string
+  tone?: 'default' | 'danger'
+  loading?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmText = '확인',
+  cancelText = '취소',
+  tone = 'default',
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !loading) onCancel()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, loading, onCancel])
+
+  if (!open) return null
+
+  const confirmClass =
+    tone === 'danger'
+      ? 'bg-red-500 hover:bg-red-600 text-white'
+      : 'bg-brand hover:bg-brand-hover text-black'
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
+      onClick={() => !loading && onCancel()}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="w-full max-w-sm rounded-3xl bg-card p-7 animate-fadeUp"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-bold text-white">{title}</h2>
+        {description && (
+          <div className="mt-2.5 text-sm text-gray-500 leading-relaxed">
+            {description}
+          </div>
+        )}
+        <div className="mt-7 flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            className={`w-full py-3.5 rounded-2xl text-sm font-semibold transition-colors disabled:opacity-60 cursor-pointer ${confirmClass}`}
+          >
+            {loading ? '처리 중…' : confirmText}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            className="w-full py-3.5 rounded-2xl text-sm font-medium text-gray-300 bg-button/80 ring-1 ring-border hover:text-white hover:ring-white/20 disabled:opacity-50 cursor-pointer transition-colors"
+          >
+            {cancelText}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #16

## 📝작업 내용

관리자가 `/admin`에서 5대 리그를 골라 AI 예측 데이터 적재를 실행하는 어드민 페이지를 구현했습니다.

- 어드민 토큰 입력 폼 (`sessionStorage` 보관, 브라우저 탭 종료 시 소멸)
- 리그 선택 후 전체 파이프라인 / 개별 단계 실행, 실행 전 확인 모달로 최종 확인
- 적재 결과 토스트 알림(react-hot-toast), 실행 이력 `localStorage` 표시
  - 현재 백엔드 적재 요청은 호출후 잊는 발식인 fire-and-forget  비동기 요청(202)이라, 결과 토스트는 접수 여부를 확인 할수 있는 확인용으로 띄우기 위해서 토스트 알림을 도입했습니다.
- API 연동 + MSW 목 핸들러 (현재 목서버에서 목 어드민 토큰은 `mockadmin`으로 구현이 되어 있습니다. 로컬 환경에서는 해당 토큰을 입력 후 접속하시면 됩니다.)
  - 메인 브랜치는 다른 조회 API들이 백엔드 연동되면서 MSW 초기화가 제거됐지만, 어드민 적재 API는 호출하면 실제로 데이터 적재가 일어나는 destructive한 동작이라 로컬에서 실수로 호출되는 걸 막기 위해 어드민 핸들러만 MSW로 남겨뒀습니다. (`onUnhandledRequest: 'bypass'` 설정이라 어드민 외 요청은 그대로 실제 백엔드로 통과합니다.)


### 스크린샷

| 어드민 인증 페이지 | 어드민 페이지 |
| :---: | :---: |
| <img width="480" src="https://github.com/user-attachments/assets/9b96c066-9607-40fb-901b-9dd3941b51c0" /> | <img width="480" src="https://github.com/user-attachments/assets/df246821-e032-4e21-8bda-7f299985d4a9" /> |



## 💬리뷰 요구사항

어드민 인증(`POST /admin/api/auth/verify`, `X-ADMIN-TOKEN` 헤더)은 백엔드와 논의 후 프론트에서 먼저 구현해뒀었고, 백엔드 명세가 확정되어 axios 호출과 에러 코드(`403 FORBIDDEN_ADMIN_TOKEN`)까지 비교해서 반영했습니다.

위 작업 내용에 적은 것처럼 어드민 적재 API만 MSW 핸들러로 남기고 나머지는 실제 백엔드로 통과시키는 방식으로 처리했는데, 이 대응이 적절한지 의견 부탁드립니다.