### PR TITLE
feat: 예측탭의 유사선수섹션 구현

### DIFF
--- a/src/entities/player/index.ts
+++ b/src/entities/player/index.ts
@@ -5,6 +5,8 @@ export { PlayerListCard } from './ui/PlayerListCard'
 export { PlayerGridCard } from './ui/PlayerGridCard'
 export {
   formatMarketValue,
+  getAdaptBarColor,
+  getAdaptBadgeStyle,
   getPositionColor,
   formatContractExpiry,
   getStatLabel,

--- a/src/entities/player/model/utils.ts
+++ b/src/entities/player/model/utils.ts
@@ -166,3 +166,12 @@ export function getAdaptBarColor(score: number): string {
   if (score >= 70) return 'bg-yellow-400'
   return 'bg-gray-400'
 }
+
+export function getAdaptBadgeStyle(score: number): string {
+  if (score >= 90)
+    return 'bg-emerald-400/20 text-emerald-400 border border-emerald-400'
+  if (score >= 80) return 'bg-sky-400/20 text-sky-400 border border-sky-400/30'
+  if (score >= 70)
+    return 'bg-yellow-400/20 text-yellow-400 border border-yellow-400'
+  return 'bg-gray-400/20 text-gray-400 border border-gray-400'
+}

--- a/src/entities/player/model/utils.ts
+++ b/src/entities/player/model/utils.ts
@@ -120,7 +120,8 @@ export function formatMarketValue(value: number | null | undefined): string {
   return `€${value}`
 }
 
-export function formatContractExpiry(value: string): string {
+export function formatContractExpiry(value: string | null | undefined): string {
+  if (value == null) return '-'
   return value.replace('-', '.')
 }
 

--- a/src/features/main/league-adaptation/ui/AdaptationItem.tsx
+++ b/src/features/main/league-adaptation/ui/AdaptationItem.tsx
@@ -19,8 +19,11 @@ export default function AdaptationItem({
   const style = RANK_STYLE[rank] ?? DEFAULT_RANK_STYLE
   const adaptColor = getAdaptColor(player.adaptScore)
   const adaptBarColor = getAdaptBarColor(player.adaptScore)
-  const mvChange = player.predictedMv - player.currentMarketValue
-  const mvChangeSign = mvChange >= 0 ? '+' : ''
+  const mvChange =
+    player.predictedMv != null && player.currentMarketValue != null
+      ? player.predictedMv - player.currentMarketValue
+      : null
+  const mvChangeSign = (mvChange ?? 0) >= 0 ? '+' : ''
   const leagueEmblem = getLeagueEmblem(player.league)
 
   return (
@@ -103,12 +106,14 @@ export default function AdaptationItem({
           <span className="text-[10px] font-medium text-white">
             {formatMarketValue(player.predictedMv)}
           </span>
-          <span
-            className={`text-[10px] font-medium ${mvChange >= 0 ? 'text-emerald-400' : 'text-red-400'}`}
-          >
-            ({mvChangeSign}
-            {formatMarketValue(Math.abs(mvChange))})
-          </span>
+          {mvChange != null && (
+            <span
+              className={`text-[10px] font-medium ${mvChange >= 0 ? 'text-emerald-400' : 'text-red-400'}`}
+            >
+              ({mvChangeSign}
+              {formatMarketValue(Math.abs(mvChange))})
+            </span>
+          )}
         </div>
       </div>
 
@@ -120,12 +125,14 @@ export default function AdaptationItem({
         <span className="font-medium text-white">
           {formatMarketValue(player.predictedMv)}
         </span>
-        <span
-          className={`font-medium ${mvChange >= 0 ? 'text-emerald-400' : 'text-red-400'}`}
-        >
-          ({mvChangeSign}
-          {formatMarketValue(Math.abs(mvChange))})
-        </span>
+        {mvChange != null && (
+          <span
+            className={`font-medium ${mvChange >= 0 ? 'text-emerald-400' : 'text-red-400'}`}
+          >
+            ({mvChangeSign}
+            {formatMarketValue(Math.abs(mvChange))})
+          </span>
+        )}
       </div>
 
       <div className="flex flex-col ml-2 items-end gap-1.5 flex-shrink-0 min-w-[52px]">

--- a/src/pages/player-detail/ui/PlayerDetailPage.tsx
+++ b/src/pages/player-detail/ui/PlayerDetailPage.tsx
@@ -86,6 +86,7 @@ export function PlayerDetailPage() {
             )}
             {activeTab === '이적 예측' && (
               <PlayerPrediction
+                player={player}
                 playerId={player.playerId}
                 position={player.position}
               />

--- a/src/widgets/player-history/ui/SeasonStatsCharts.tsx
+++ b/src/widgets/player-history/ui/SeasonStatsCharts.tsx
@@ -47,7 +47,11 @@ function buildChartData(history: SeasonHistory[]): ChartRow[] {
   })
 }
 
-function formatTooltipValue(dataKey: string, value: number): string {
+function formatTooltipValue(
+  dataKey: string,
+  value: number | null | undefined,
+): string {
+  if (value == null || !Number.isFinite(value)) return '-'
   if (dataKey === 'rating') return value.toFixed(1)
   if (dataKey === 'pass_') return `${value.toFixed(1)}%`
   return Math.round(value).toLocaleString('en-US')

--- a/src/widgets/player-prediction/model/type.ts
+++ b/src/widgets/player-prediction/model/type.ts
@@ -1,3 +1,4 @@
+import type { PlayerDetailResponse } from '@/entities/player'
 import type { Position } from '@/shared/model/types'
 
 export type KeyStat = { label: string; value: number }
@@ -40,6 +41,7 @@ export type StatCardProps = {
 }
 
 export type PlayerPredictionProps = {
+  player: PlayerDetailResponse
   playerId: number
   position: Position
 }

--- a/src/widgets/player-prediction/model/type.ts
+++ b/src/widgets/player-prediction/model/type.ts
@@ -116,12 +116,11 @@ export interface SimilarPlayer {
 export interface PlayerPredictionResponseProps {
   data: {
     currentStats: PredictionCurrentStats
-    predictedStats: PredictionPredictedStats
-    statChanges: PredictionStatChanges
-    adaptScore: AdaptScore
+    predictedStats: PredictionPredictedStats | null
+    statChanges: PredictionStatChanges | null
+    adaptScore: AdaptScore | null
     similarPlayers: {
       results: SimilarPlayer[]
     }
-    llmSummary: string
   }
 }

--- a/src/widgets/player-prediction/ui/AdaptScoreCard.tsx
+++ b/src/widgets/player-prediction/ui/AdaptScoreCard.tsx
@@ -13,7 +13,7 @@ export function AdaptScoreCard({
 
   return (
     <div
-      className=" mt-5 flex flex-col items-center justify-between gap-3 px-8 py-5.5 rounded-2xl border"
+      className="mt-5 flex flex-col items-center justify-between gap-3 px-5 sm:px-8 py-5 rounded-2xl border"
       style={{
         background:
           'linear-gradient(to bottom right, rgba(0,199,133,0.094), rgba(0,199,133,0.03))',
@@ -25,9 +25,11 @@ export function AdaptScoreCard({
         {leagueLabel} 적응도 점수
       </span>
 
-      <div className="flex items-end gap-4">
-        <span className="text-7xl font-bold text-emerald-400">{total}</span>
-        <span className="text-3xl text-gray-500 ">/ 100</span>
+      <div className="flex items-end gap-3">
+        <span className="text-5xl sm:text-7xl font-bold text-emerald-400">
+          {total}
+        </span>
+        <span className="text-xl sm:text-3xl text-gray-500">/ 100</span>
       </div>
 
       <div className="w-full max-w-xs h-3 mt-1 rounded-full bg-white/10">

--- a/src/widgets/player-prediction/ui/AdaptScoreCard.tsx
+++ b/src/widgets/player-prediction/ui/AdaptScoreCard.tsx
@@ -27,7 +27,7 @@ export function AdaptScoreCard({
 
       <div className="flex items-end gap-3">
         <span className="text-5xl sm:text-7xl font-bold text-emerald-400">
-          {total}
+          {total ?? '-'}
         </span>
         <span className="text-xl sm:text-3xl text-gray-500">/ 100</span>
       </div>
@@ -35,11 +35,13 @@ export function AdaptScoreCard({
       <div className="w-full max-w-xs h-3 mt-1 rounded-full bg-white/10">
         <div
           className="h-3 rounded-full bg-emerald-400 transition-all duration-500"
-          style={{ width: `${total}%` }}
+          style={{ width: `${total ?? 0}%` }}
         />
       </div>
 
-      <span className="text-sm text-emerald-400">{getLabel(total)}</span>
+      <span className="text-sm text-emerald-400">
+        {total != null ? getLabel(total) : '-'}
+      </span>
     </div>
   )
 }

--- a/src/widgets/player-prediction/ui/MarketValueSection.tsx
+++ b/src/widgets/player-prediction/ui/MarketValueSection.tsx
@@ -10,7 +10,7 @@ export function MarketValueSection({
 
   return (
     <div
-      className="mt-4 flex items-center justify-between px-6 py-5 rounded-2xl"
+      className="mt-4 flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-0 justify-between px-4 sm:px-6 py-4 sm:py-5 rounded-2xl"
       style={{
         background: 'rgba(0,199,133,0.06)',
         border: '1px solid rgba(0,199,133,0.20)',

--- a/src/widgets/player-prediction/ui/MarketValueSection.tsx
+++ b/src/widgets/player-prediction/ui/MarketValueSection.tsx
@@ -1,3 +1,4 @@
+import { formatMarketValue } from '@/entities/player'
 import type { MarketValueSectionProps } from '../model/type'
 
 export function MarketValueSection({
@@ -5,8 +6,14 @@ export function MarketValueSection({
   predictedMarketValue,
   marketValueChangeRate,
 }: MarketValueSectionProps) {
-  const changePercent = Math.round(marketValueChangeRate * 100)
-  const isPositive = changePercent >= 0
+  const changePercent =
+    marketValueChangeRate != null
+      ? Math.round(marketValueChangeRate * 100)
+      : null
+  const isPositive = (changePercent ?? 0) >= 0
+
+  const currentDisplay = formatMarketValue(currentMarketValue)
+  const predictedDisplay = formatMarketValue(predictedMarketValue)
 
   return (
     <div
@@ -20,11 +27,11 @@ export function MarketValueSection({
         <span className="text-xs text-gray-400">예측 시장가치 변화</span>
         <div className="flex items-center gap-3">
           <span className="text-xl font-semibold text-white">
-            €{(currentMarketValue / 1000000).toFixed(0)}M
+            {currentDisplay}
           </span>
           <span className="text-gray-500">→</span>
           <span className="text-2xl font-bold text-emerald-400">
-            €{(predictedMarketValue / 1000000).toFixed(0)}M
+            {predictedDisplay}
           </span>
         </div>
       </div>
@@ -33,11 +40,16 @@ export function MarketValueSection({
         <span
           className={`text-xl font-bold ${isPositive ? 'text-emerald-400' : 'text-red-400'}`}
         >
-          {isPositive ? '+' : ''}
-          {changePercent}%
+          {changePercent != null
+            ? `${isPositive ? '+' : ''}${changePercent}%`
+            : '-'}
         </span>
         <span className="text-xs text-text-gray">
-          {isPositive ? '가치 상승 예측' : '가치 하락 예측'}
+          {changePercent != null
+            ? isPositive
+              ? '가치 상승 예측'
+              : '가치 하락 예측'
+            : '데이터 없음'}
         </span>
       </div>
     </div>

--- a/src/widgets/player-prediction/ui/PlayerPrediction.tsx
+++ b/src/widgets/player-prediction/ui/PlayerPrediction.tsx
@@ -10,6 +10,7 @@ import { useLeaguePrediction } from '../model/useLeaguePrediction'
 import { SimilarPlayerSection } from './SimilarPlayerSection'
 
 export function PlayerPrediction({
+  player,
   playerId,
   position,
 }: PlayerPredictionProps) {
@@ -55,7 +56,7 @@ export function PlayerPrediction({
             statChanges={data.statChanges}
             leagueLabel={selectedTab.label}
             marketValueChangeRate={data.predictedStats.marketValueChangeRate}
-            teamLabel="Sporting CP" //찬빈오빠꺼랑 머지할때 고치기
+            teamLabel={player.team}
           />
 
           <MarketValueSection

--- a/src/widgets/player-prediction/ui/PlayerPrediction.tsx
+++ b/src/widgets/player-prediction/ui/PlayerPrediction.tsx
@@ -31,7 +31,7 @@ export function PlayerPrediction({
               isActive={selected === tab.key}
               onClick={setSelected}
               variant="prediction"
-              total={data?.adaptScore.total}
+              total={data?.adaptScore?.total}
             />
           ))}
         </div>
@@ -43,27 +43,39 @@ export function PlayerPrediction({
         </div>
       ) : (
         <>
-          <AdaptScoreCard
-            leagueLabel={selectedTab.label}
-            leagueFlag={selectedTab.flag}
-            total={data.adaptScore.total}
-          />
+          {data.adaptScore && data.predictedStats && data.statChanges ? (
+            <>
+              <AdaptScoreCard
+                leagueLabel={selectedTab.label}
+                leagueFlag={selectedTab.flag}
+                total={data.adaptScore.total}
+              />
 
-          <StatComparisonSection
-            position={position}
-            currentStats={data.currentStats}
-            predictedStats={data.predictedStats}
-            statChanges={data.statChanges}
-            leagueLabel={selectedTab.label}
-            marketValueChangeRate={data.predictedStats.marketValueChangeRate}
-            teamLabel={player.team}
-          />
+              <StatComparisonSection
+                position={position}
+                currentStats={data.currentStats}
+                predictedStats={data.predictedStats}
+                statChanges={data.statChanges}
+                leagueLabel={selectedTab.label}
+                marketValueChangeRate={
+                  data.predictedStats.marketValueChangeRate
+                }
+                teamLabel={player.team}
+              />
 
-          <MarketValueSection
-            currentMarketValue={data.currentStats.marketValue}
-            predictedMarketValue={data.predictedStats.marketValue}
-            marketValueChangeRate={data.predictedStats.marketValueChangeRate}
-          />
+              <MarketValueSection
+                currentMarketValue={data.currentStats.marketValue}
+                predictedMarketValue={data.predictedStats.marketValue}
+                marketValueChangeRate={
+                  data.predictedStats.marketValueChangeRate
+                }
+              />
+            </>
+          ) : (
+            <div className="mt-6 rounded-xl bg-card/80 p-8 text-center text-sm text-gray-400">
+              선택한 리그의 예측 데이터가 아직 없습니다.
+            </div>
+          )}
 
           {data.similarPlayers?.results?.length > 0 && (
             <SimilarPlayerSection

--- a/src/widgets/player-prediction/ui/PlayerPrediction.tsx
+++ b/src/widgets/player-prediction/ui/PlayerPrediction.tsx
@@ -7,6 +7,7 @@ import type { PlayerPredictionProps } from '../model/type'
 import { StatComparisonSection } from './StatComparisonSection'
 import { MarketValueSection } from './MarketValueSection'
 import { useLeaguePrediction } from '../model/useLeaguePrediction'
+import { SimilarPlayerSection } from './SimilarPlayerSection'
 
 export function PlayerPrediction({
   playerId,
@@ -62,6 +63,10 @@ export function PlayerPrediction({
             predictedMarketValue={data.predictedStats.marketValue}
             marketValueChangeRate={data.predictedStats.marketValueChangeRate}
           />
+
+          {data.similarPlayers?.results?.length > 0 && (
+            <SimilarPlayerSection players={data.similarPlayers.results} />
+          )}
         </>
       )}
     </div>

--- a/src/widgets/player-prediction/ui/PlayerPrediction.tsx
+++ b/src/widgets/player-prediction/ui/PlayerPrediction.tsx
@@ -66,7 +66,10 @@ export function PlayerPrediction({
           />
 
           {data.similarPlayers?.results?.length > 0 && (
-            <SimilarPlayerSection players={data.similarPlayers.results} />
+            <SimilarPlayerSection
+              players={data.similarPlayers.results}
+              player={player}
+            />
           )}
         </>
       )}

--- a/src/widgets/player-prediction/ui/SimilarPlayer.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayer.tsx
@@ -1,4 +1,5 @@
 import { formatMarketValue } from '@/entities/player'
+import { TOP_LEAGUE_TABS } from '@/shared/lib/league'
 import type { SimilarPlayer } from '../model/type'
 
 interface SimilarPlayerCardProps {
@@ -35,7 +36,7 @@ export default function SimilarPlayerCard({
   const assists = player.keyStats.find((s) => s.label === 'assists')?.value
 
   return (
-    <div className="flex flex-col rounded-xl border border-zinc-800 bg-[#111827] overflow-hidden w-full">
+    <div className="flex flex-col rounded-xl border border-text-gray/20 bg-card/60 overflow-hidden w-full">
       <div className={`h-1 w-full ${style.bar}`} />
 
       <div className="p-4 flex flex-col gap-3">
@@ -45,7 +46,7 @@ export default function SimilarPlayerCard({
           >
             {Math.round(similarityScore * 100)}% 일치
           </span>
-          <span className="text-xs text-zinc-400 bg-zinc-800 px-2.5 py-1 rounded-md border border-zinc-700">
+          <span className="text-xs text-text-gray bg-button px-2.5 py-1 rounded-md">
             {player.position}
           </span>
         </div>
@@ -54,20 +55,30 @@ export default function SimilarPlayerCard({
           <img
             src={player.imageUrl}
             alt={player.name}
-            className="w-11 h-11 rounded-lg object-cover bg-zinc-800 border border-zinc-700"
+            className="w-11 h-11 rounded-lg object-cover bg-zinc-800"
           />
           <div className="flex flex-col">
             <span className="text-sm font-medium text-white">
               {player.name}
             </span>
-            <span className="text-xs text-zinc-400">{player.team}</span>
-            <span className="text-xs text-zinc-500">🇩🇪 {player.league}</span>
+            <span className="text-xs text-text-gray">{player.team}</span>
+            <span className="text-xs text-text-gray">
+              {(() => {
+                const tab = TOP_LEAGUE_TABS.find((t) => t.key === player.league)
+                return tab ? (
+                  <span className="flex items-center gap-1">
+                    <img className="w-4" src={tab.flag} alt="리그 국기" />
+                    {tab.label}
+                  </span>
+                ) : (
+                  player.league
+                )
+              })()}
+            </span>
           </div>
         </div>
 
-        <div className="border-t border-zinc-800" />
-
-        <div className="grid grid-cols-3 divide-x divide-zinc-800 text-center">
+        <div className="grid grid-cols-3 rounded-lg p-3 bg-card divide-x divide-text-gray text-center">
           <div className="flex flex-col gap-1 pr-2">
             <span className="text-xs text-zinc-500">골</span>
             <span className="text-lg font-medium text-white">
@@ -89,8 +100,8 @@ export default function SimilarPlayerCard({
         </div>
 
         <div className="flex items-center justify-between">
-          <span className="text-xs text-zinc-500">시장가치</span>
-          <span className="text-sm font-medium text-[#1d9e75]">
+          <span className="text-xs text-text-gray">시장가치</span>
+          <span className="text-sm font-medium text-brand">
             {marketValueLabel}
           </span>
         </div>

--- a/src/widgets/player-prediction/ui/SimilarPlayer.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayer.tsx
@@ -72,7 +72,7 @@ export default function SimilarPlayerCard({ data }: SimilarPlayerCardProps) {
               key={stat.label}
               className={`flex flex-col gap-1 ${i === 0 ? 'pr-2' : i === player.keyStats.length - 1 ? 'pl-2' : 'px-2'}`}
             >
-              <span className="text-xs text-text-gray">
+              <span className="text-xs text-text-gray truncate">
                 {LABEL_MAP[stat.label] ?? stat.label}
               </span>
               <span className="text-lg font-medium text-white">

--- a/src/widgets/player-prediction/ui/SimilarPlayer.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayer.tsx
@@ -1,3 +1,4 @@
+import { formatMarketValue } from '@/entities/player'
 import type { SimilarPlayer } from '../model/type'
 
 interface SimilarPlayerCardProps {
@@ -27,10 +28,7 @@ export default function SimilarPlayerCard({
   const { player, similarityScore } = data
   const style = RANK_STYLES[rank]
 
-  const marketValueLabel =
-    player.marketValue >= 1_000_000
-      ? `€${(player.marketValue / 1_000_000).toFixed(0)}M`
-      : `€${(player.marketValue / 1_000).toFixed(0)}K`
+  const marketValueLabel = formatMarketValue(player.marketValue)
 
   const rating = player.keyStats.find((s) => s.label === 'rating')?.value
   const goals = player.keyStats.find((s) => s.label === 'goals')?.value
@@ -38,11 +36,9 @@ export default function SimilarPlayerCard({
 
   return (
     <div className="flex flex-col rounded-xl border border-zinc-800 bg-[#111827] overflow-hidden w-full">
-      {/* 상단 컬러 바 */}
       <div className={`h-1 w-full ${style.bar}`} />
 
       <div className="p-4 flex flex-col gap-3">
-        {/* 일치율 + 포지션 */}
         <div className="flex items-center justify-between">
           <span
             className={`text-xs font-medium px-2.5 py-1 rounded-full ${style.badge}`}

--- a/src/widgets/player-prediction/ui/SimilarPlayer.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayer.tsx
@@ -35,11 +35,13 @@ export default function SimilarPlayerCard({ data }: SimilarPlayerCardProps) {
         </div>
 
         <div className="flex items-center gap-3">
-          <img
-            src={player.imageUrl}
-            alt={player.name}
-            className="w-11 h-11 rounded-lg object-cover bg-zinc-800"
-          />
+          {player.imageUrl && (
+            <img
+              src={player.imageUrl}
+              alt={player.name}
+              className="w-11 h-11 rounded-lg object-cover bg-zinc-800"
+            />
+          )}
           <div className="flex flex-col">
             <span className="text-sm font-medium text-white">
               {player.name}

--- a/src/widgets/player-prediction/ui/SimilarPlayer.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayer.tsx
@@ -1,45 +1,31 @@
-import { formatMarketValue } from '@/entities/player'
+import {
+  formatMarketValue,
+  getAdaptBarColor,
+  getAdaptBadgeStyle,
+} from '@/entities/player'
 import { TOP_LEAGUE_TABS } from '@/shared/lib/league'
 import { LABEL_MAP } from '../model/predictionConstants'
 import type { SimilarPlayer } from '../model/type'
 
 interface SimilarPlayerCardProps {
   data: SimilarPlayer
-  rank: 1 | 2 | 3
 }
 
-const RANK_STYLES = {
-  1: {
-    bar: 'bg-[#1d9e75]',
-    badge: 'bg-[#e1f5ee] text-[#085041]',
-  },
-  2: {
-    bar: 'bg-[#888780]',
-    badge: 'bg-[#f1efe8] text-[#444441]',
-  },
-  3: {
-    bar: 'bg-[#ba7517]',
-    badge: 'bg-[#faeeda] text-[#633806]',
-  },
-}
-
-export default function SimilarPlayerCard({
-  data,
-  rank,
-}: SimilarPlayerCardProps) {
+export default function SimilarPlayerCard({ data }: SimilarPlayerCardProps) {
   const { player, similarityScore } = data
-  const style = RANK_STYLES[rank]
 
   const marketValueLabel = formatMarketValue(player.marketValue)
 
   return (
     <div className="flex flex-col rounded-xl border border-text-gray/20 bg-card/60 overflow-hidden w-full">
-      <div className={`h-1 w-full ${style.bar}`} />
+      <div
+        className={`h-1 w-full ${getAdaptBarColor(Math.round(similarityScore * 100))}`}
+      />
 
       <div className="p-4 flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <span
-            className={`text-xs font-medium px-2.5 py-1 rounded-full ${style.badge}`}
+            className={`text-xs font-medium px-2.5 py-1 rounded-full ${getAdaptBadgeStyle(Math.round(similarityScore * 100))}`}
           >
             {Math.round(similarityScore * 100)}% 일치
           </span>
@@ -86,11 +72,11 @@ export default function SimilarPlayerCard({
               key={stat.label}
               className={`flex flex-col gap-1 ${i === 0 ? 'pr-2' : i === player.keyStats.length - 1 ? 'pl-2' : 'px-2'}`}
             >
-              <span className="text-xs text-zinc-500">
+              <span className="text-xs text-text-gray">
                 {LABEL_MAP[stat.label] ?? stat.label}
               </span>
               <span className="text-lg font-medium text-white">
-                {stat.value ?? '-'}
+                {stat.value?.toLocaleString() ?? '-'}
               </span>
             </div>
           ))}

--- a/src/widgets/player-prediction/ui/SimilarPlayer.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayer.tsx
@@ -1,0 +1,104 @@
+import type { SimilarPlayer } from '../model/type'
+
+interface SimilarPlayerCardProps {
+  data: SimilarPlayer
+  rank: 1 | 2 | 3
+}
+
+const RANK_STYLES = {
+  1: {
+    bar: 'bg-[#1d9e75]',
+    badge: 'bg-[#e1f5ee] text-[#085041]',
+  },
+  2: {
+    bar: 'bg-[#888780]',
+    badge: 'bg-[#f1efe8] text-[#444441]',
+  },
+  3: {
+    bar: 'bg-[#ba7517]',
+    badge: 'bg-[#faeeda] text-[#633806]',
+  },
+}
+
+export default function SimilarPlayerCard({
+  data,
+  rank,
+}: SimilarPlayerCardProps) {
+  const { player, similarityScore } = data
+  const style = RANK_STYLES[rank]
+
+  const marketValueLabel =
+    player.marketValue >= 1_000_000
+      ? `€${(player.marketValue / 1_000_000).toFixed(0)}M`
+      : `€${(player.marketValue / 1_000).toFixed(0)}K`
+
+  const rating = player.keyStats.find((s) => s.label === 'rating')?.value
+  const goals = player.keyStats.find((s) => s.label === 'goals')?.value
+  const assists = player.keyStats.find((s) => s.label === 'assists')?.value
+
+  return (
+    <div className="flex flex-col rounded-xl border border-zinc-800 bg-[#111827] overflow-hidden w-full">
+      {/* 상단 컬러 바 */}
+      <div className={`h-1 w-full ${style.bar}`} />
+
+      <div className="p-4 flex flex-col gap-3">
+        {/* 일치율 + 포지션 */}
+        <div className="flex items-center justify-between">
+          <span
+            className={`text-xs font-medium px-2.5 py-1 rounded-full ${style.badge}`}
+          >
+            {Math.round(similarityScore * 100)}% 일치
+          </span>
+          <span className="text-xs text-zinc-400 bg-zinc-800 px-2.5 py-1 rounded-md border border-zinc-700">
+            {player.position}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <img
+            src={player.imageUrl}
+            alt={player.name}
+            className="w-11 h-11 rounded-lg object-cover bg-zinc-800 border border-zinc-700"
+          />
+          <div className="flex flex-col">
+            <span className="text-sm font-medium text-white">
+              {player.name}
+            </span>
+            <span className="text-xs text-zinc-400">{player.team}</span>
+            <span className="text-xs text-zinc-500">🇩🇪 {player.league}</span>
+          </div>
+        </div>
+
+        <div className="border-t border-zinc-800" />
+
+        <div className="grid grid-cols-3 divide-x divide-zinc-800 text-center">
+          <div className="flex flex-col gap-1 pr-2">
+            <span className="text-xs text-zinc-500">골</span>
+            <span className="text-lg font-medium text-white">
+              {goals ?? '-'}
+            </span>
+          </div>
+          <div className="flex flex-col gap-1 px-2">
+            <span className="text-xs text-zinc-500">도움</span>
+            <span className="text-lg font-medium text-white">
+              {assists ?? '-'}
+            </span>
+          </div>
+          <div className="flex flex-col gap-1 pl-2">
+            <span className="text-xs text-zinc-500">평점</span>
+            <span className="text-lg font-medium text-[#1d9e75]">
+              {rating ?? '-'}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-zinc-500">시장가치</span>
+          <span className="text-sm font-medium text-[#1d9e75]">
+            {marketValueLabel}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/widgets/player-prediction/ui/SimilarPlayer.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayer.tsx
@@ -1,5 +1,6 @@
 import { formatMarketValue } from '@/entities/player'
 import { TOP_LEAGUE_TABS } from '@/shared/lib/league'
+import { LABEL_MAP } from '../model/predictionConstants'
 import type { SimilarPlayer } from '../model/type'
 
 interface SimilarPlayerCardProps {
@@ -30,10 +31,6 @@ export default function SimilarPlayerCard({
   const style = RANK_STYLES[rank]
 
   const marketValueLabel = formatMarketValue(player.marketValue)
-
-  const rating = player.keyStats.find((s) => s.label === 'rating')?.value
-  const goals = player.keyStats.find((s) => s.label === 'goals')?.value
-  const assists = player.keyStats.find((s) => s.label === 'assists')?.value
 
   return (
     <div className="flex flex-col rounded-xl border border-text-gray/20 bg-card/60 overflow-hidden w-full">
@@ -78,25 +75,25 @@ export default function SimilarPlayerCard({
           </div>
         </div>
 
-        <div className="grid grid-cols-3 rounded-lg p-3 bg-card divide-x divide-text-gray text-center">
-          <div className="flex flex-col gap-1 pr-2">
-            <span className="text-xs text-zinc-500">골</span>
-            <span className="text-lg font-medium text-white">
-              {goals ?? '-'}
-            </span>
-          </div>
-          <div className="flex flex-col gap-1 px-2">
-            <span className="text-xs text-zinc-500">도움</span>
-            <span className="text-lg font-medium text-white">
-              {assists ?? '-'}
-            </span>
-          </div>
-          <div className="flex flex-col gap-1 pl-2">
-            <span className="text-xs text-zinc-500">평점</span>
-            <span className="text-lg font-medium text-[#1d9e75]">
-              {rating ?? '-'}
-            </span>
-          </div>
+        <div
+          className="grid rounded-lg p-3 bg-card divide-x divide-text-gray text-center"
+          style={{
+            gridTemplateColumns: `repeat(${player.keyStats.length}, 1fr)`,
+          }}
+        >
+          {player.keyStats.map((stat, i) => (
+            <div
+              key={stat.label}
+              className={`flex flex-col gap-1 ${i === 0 ? 'pr-2' : i === player.keyStats.length - 1 ? 'pl-2' : 'px-2'}`}
+            >
+              <span className="text-xs text-zinc-500">
+                {LABEL_MAP[stat.label] ?? stat.label}
+              </span>
+              <span className="text-lg font-medium text-white">
+                {stat.value ?? '-'}
+              </span>
+            </div>
+          ))}
         </div>
 
         <div className="flex items-center justify-between">

--- a/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
@@ -12,12 +12,8 @@ export function SimilarPlayerSection({ players }: Props) {
         예측 유사 선수
       </h2>
       <div className="grid grid-cols-3 gap-4">
-        {players.map((player, i) => (
-          <SimilarPlayerCard
-            key={player.player.playerId}
-            data={player}
-            rank={(i + 1) as 1 | 2 | 3}
-          />
+        {players.map((player) => (
+          <SimilarPlayerCard key={player.player.playerId} data={player} />
         ))}
       </div>
     </div>

--- a/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
@@ -1,0 +1,25 @@
+import SimilarPlayerCard from './SimilarPlayer'
+import type { SimilarPlayer } from '../model/type'
+
+interface Props {
+  players: SimilarPlayer[]
+}
+
+export function SimilarPlayerSection({ players }: Props) {
+  return (
+    <div className="rounded-2xl bg-card/60 p-6 mt-4">
+      <h2 className="text-sm font-medium text-gray-400 mb-3 text-white">
+        예측 유사 선수
+      </h2>
+      <div className="grid grid-cols-3 gap-4">
+        {players.map((p, i) => (
+          <SimilarPlayerCard
+            key={p.player.playerId}
+            data={p}
+            rank={(i + 1) as 1 | 2 | 3}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
@@ -15,13 +15,11 @@ export function SimilarPlayerSection({ player, players }: Props) {
 
   return (
     <div className="rounded-2xl bg-card/60 p-6 mt-4">
-      <h2 className="text-sm font-medium text-gray-400 mb-1 text-white">
-        예측 유사 선수
-      </h2>
+      <h2 className="text-sm font-medium text-white mb-1">예측 유사 선수</h2>
       <p className="text-text-gray text-xs mb-3 flex items-center flex-wrap">
         {player.name}의 예측 퍼포먼스 지표를 기반으로
         <span className="inline-flex items-center gap-1 ml-2">
-          <img className="w-3" src={flag} alt="리그 국기" />
+          {flag && <img className="w-3" src={flag} alt="리그 국기" />}
           {league}
         </span>
         에서 가장 유사한 선수 3인을 선발했습니다.

--- a/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
@@ -12,10 +12,10 @@ export function SimilarPlayerSection({ players }: Props) {
         예측 유사 선수
       </h2>
       <div className="grid grid-cols-3 gap-4">
-        {players.map((p, i) => (
+        {players.map((player, i) => (
           <SimilarPlayerCard
-            key={p.player.playerId}
-            data={p}
+            key={player.player.playerId}
+            data={player}
             rank={(i + 1) as 1 | 2 | 3}
           />
         ))}

--- a/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
@@ -26,7 +26,7 @@ export function SimilarPlayerSection({ player, players }: Props) {
         </span>
         에서 가장 유사한 선수 3인을 선발했습니다.
       </p>
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         {players.map((player) => (
           <SimilarPlayerCard key={player.player.playerId} data={player} />
         ))}

--- a/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
+++ b/src/widgets/player-prediction/ui/SimilarPlayerSection.tsx
@@ -1,16 +1,31 @@
 import SimilarPlayerCard from './SimilarPlayer'
 import type { SimilarPlayer } from '../model/type'
+import type { PlayerDetailResponse } from '@/entities/player'
+import { TOP_LEAGUE_TABS } from '@/shared/lib/league'
 
 interface Props {
+  player: PlayerDetailResponse
   players: SimilarPlayer[]
 }
 
-export function SimilarPlayerSection({ players }: Props) {
+export function SimilarPlayerSection({ player, players }: Props) {
+  const tab = TOP_LEAGUE_TABS.find((t) => t.key === players[0].player.league)
+  const flag = tab?.flag ?? ''
+  const league = tab?.label ?? player.league
+
   return (
     <div className="rounded-2xl bg-card/60 p-6 mt-4">
-      <h2 className="text-sm font-medium text-gray-400 mb-3 text-white">
+      <h2 className="text-sm font-medium text-gray-400 mb-1 text-white">
         예측 유사 선수
       </h2>
+      <p className="text-text-gray text-xs mb-3 flex items-center flex-wrap">
+        {player.name}의 예측 퍼포먼스 지표를 기반으로
+        <span className="inline-flex items-center gap-1 ml-2">
+          <img className="w-3" src={flag} alt="리그 국기" />
+          {league}
+        </span>
+        에서 가장 유사한 선수 3인을 선발했습니다.
+      </p>
       <div className="grid grid-cols-3 gap-4">
         {players.map((player) => (
           <SimilarPlayerCard key={player.player.playerId} data={player} />

--- a/src/widgets/player-prediction/ui/StatCard.tsx
+++ b/src/widgets/player-prediction/ui/StatCard.tsx
@@ -39,7 +39,7 @@ export function StatCard({ title, stats, isPredict, changes }: StatCardProps) {
               </span>
               <div className="flex items-center gap-2">
                 <span className="text-sm font-medium text-white">
-                  {stat.value.toLocaleString()}
+                  {stat.value?.toLocaleString()}
                 </span>
                 {isPredict && change !== undefined && (
                   <span

--- a/src/widgets/player-prediction/ui/StatCard.tsx
+++ b/src/widgets/player-prediction/ui/StatCard.tsx
@@ -39,7 +39,7 @@ export function StatCard({ title, stats, isPredict, changes }: StatCardProps) {
               </span>
               <div className="flex items-center gap-2">
                 <span className="text-sm font-medium text-white">
-                  {stat.value?.toLocaleString()}
+                  {stat.value != null ? stat.value.toLocaleString() : '-'}
                 </span>
                 {isPredict && change !== undefined && (
                   <span
@@ -59,9 +59,11 @@ export function StatCard({ title, stats, isPredict, changes }: StatCardProps) {
             <span className="text-sm text-gray-400">{label}</span>
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium text-white">
-                {key === 'marketValue'
-                  ? `€${(Number(value) / 1000000).toFixed(0)}M`
-                  : Number(value).toLocaleString()}
+                {value == null
+                  ? '-'
+                  : key === 'marketValue'
+                    ? `€${(Number(value) / 1000000).toFixed(0)}M`
+                    : Number(value).toLocaleString()}
               </span>
               {isPredict && change !== undefined && (
                 <span
@@ -69,9 +71,11 @@ export function StatCard({ title, stats, isPredict, changes }: StatCardProps) {
                   ${Number(change) > 0 ? 'text-emerald-400' : 'text-red-400'}`}
                 >
                   {Number(change) > 0 ? '▲' : '▼'}{' '}
-                  {key === 'marketValue'
-                    ? `€${(Math.abs(Number(change)) / 1000000).toFixed(0)}M`
-                    : Math.abs(Number(change))}
+                  {change == null
+                    ? '-'
+                    : key === 'marketValue'
+                      ? `€${(Math.abs(Number(change)) / 1000000).toFixed(0)}M`
+                      : Math.abs(Number(change))}
                 </span>
               )}
             </div>

--- a/src/widgets/player-prediction/ui/StatChartSection.tsx
+++ b/src/widgets/player-prediction/ui/StatChartSection.tsx
@@ -85,7 +85,7 @@ export function StatChartSection({
   const legendType = allDown ? 'down' : allUp ? 'up' : 'mixed'
 
   return (
-    <div className="rounded-2xl bg-card/60 p-6 mt-4">
+    <div className="rounded-2xl bg-card/60 p-4 sm:p-6 mt-4">
       <div className="flex items-center justify-between mb-4">
         <span className="text-sm font-medium text-white">스탯 비교 시각화</span>
         <div className="flex items-center gap-3">

--- a/src/widgets/player-prediction/ui/StatChartSection.tsx
+++ b/src/widgets/player-prediction/ui/StatChartSection.tsx
@@ -76,7 +76,7 @@ export function StatChartSection({
   const chartData = [
     ...currentStats.keyStats.map((stat, index) => ({
       name: LABEL_MAP[stat.label] ?? stat.label,
-      현재: stat.value,
+      현재: stat.value ?? 0,
       예측: predictedStats.keyStats[index]?.value ?? 0,
     })),
   ]

--- a/src/widgets/player-prediction/ui/StatComparisonSection.tsx
+++ b/src/widgets/player-prediction/ui/StatComparisonSection.tsx
@@ -11,7 +11,7 @@ export function StatComparisonSection({
 }: StatComparisonSectionProps) {
   return (
     <>
-      <div className="flex gap-4 mt-4">
+      <div className="flex flex-col sm:flex-row gap-4 mt-4">
         <StatCard
           title={`현재 (${teamLabel})`}
           stats={currentStats}


### PR DESCRIPTION
## #️⃣연관된 이슈

#20 

## 📝작업 내용

> 유사선수 섹션 구현 (섹션 및 카드)
> 상세페이지의 예측탭에 대한 반응형 구현
> 백엔드에서 내려오는 값이 Null 일시 발생하는 문제 해결

### 스크린샷 (선택)
<img width="852" height="787" alt="image" src="https://github.com/user-attachments/assets/b48d556b-bf7d-428e-878a-6f9845b6ba8a" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
