### PR TITLE
fix: 히스토리/검색 카드 지표 라벨 한글 매핑 및 그래프 렌더링 수정

### DIFF
--- a/src/entities/player/model/chartConfig.ts
+++ b/src/entities/player/model/chartConfig.ts
@@ -29,19 +29,16 @@ export const CHART_TOOLTIP_LABEL_STYLE = {
 } as const
 
 export const HISTORY_STAT_COLOR_MAP: Record<string, string> = {
-  Goals: CHART_COLORS.brand,
-  Assists: CHART_COLORS.yellow,
-  SoT: CHART_COLORS.sky,
-  'Key Passes': CHART_COLORS.orange,
-  Passes: CHART_COLORS.cyan,
-  'Pass%': CHART_COLORS.brand,
-  Tackles: CHART_COLORS.orange,
-  Interceptions: CHART_COLORS.sky,
-  Clearances: CHART_COLORS.yellow,
-  'Aerials Won': CHART_COLORS.rose,
-  Saves: CHART_COLORS.brand,
-  GA: CHART_COLORS.rose,
-  'Clean Sheets': CHART_COLORS.sky,
+  'Goals/90': CHART_COLORS.brand,
+  'Shots/90': CHART_COLORS.sky,
+  'SuccessfulDribbles/90': CHART_COLORS.orange,
+  'KeyPass/90': CHART_COLORS.orange,
+  'Passes/90': CHART_COLORS.cyan,
+  'Tackles/90': CHART_COLORS.sky,
+  'AerialsWon/90': CHART_COLORS.rose,
+  'Blocks/90': CHART_COLORS.yellow,
+  PassAccuracy: CHART_COLORS.brand,
+  CleanSheets: CHART_COLORS.sky,
 }
 
 export const RATING_CHART_COLOR = CHART_COLORS.violet
@@ -55,25 +52,18 @@ export interface StatGroup {
 
 export const STAT_GROUPS_BY_POSITION: Record<Position, StatGroup[]> = {
   FW: [
-    { title: '골 / 도움 / 유효슈팅', statLabels: ['Goals', 'Assists', 'SoT'] },
-    { title: '키패스 (공격 기여)', statLabels: ['Key Passes'] },
+    { title: '득점 / 슈팅', statLabels: ['Goals/90', 'Shots/90'] },
+    { title: '드리블 성공', statLabels: ['SuccessfulDribbles/90'] },
   ],
   MF: [
-    {
-      title: '도움 / 키패스 / 패스',
-      statLabels: ['Assists', 'Key Passes', 'Passes'],
-    },
-    { title: '패스 정확도', statLabels: ['Pass%'] },
+    { title: '키패스 / 태클', statLabels: ['KeyPass/90', 'Tackles/90'] },
+    { title: '패스', statLabels: ['Passes/90'] },
   ],
   DF: [
-    {
-      title: '태클 / 인터셉트 / 클리어',
-      statLabels: ['Tackles', 'Interceptions', 'Clearances'],
-    },
-    { title: '공중볼 경합', statLabels: ['Aerials Won'] },
+    { title: '공중볼 경합 / 블록', statLabels: ['AerialsWon/90', 'Blocks/90'] },
   ],
   GK: [
-    { title: '선방 / 실점', statLabels: ['Saves', 'GA'] },
-    { title: '클린시트', statLabels: ['Clean Sheets'] },
+    { title: '패스 정확도', statLabels: ['PassAccuracy'] },
+    { title: '클린시트', statLabels: ['CleanSheets'] },
   ],
 }

--- a/src/entities/player/model/utils.ts
+++ b/src/entities/player/model/utils.ts
@@ -3,12 +3,12 @@ import type { Trend } from './types'
 export const STAT_LABEL_MAP: Record<string, string> = {
   Rating: '평점',
   'Goals/90': '득점',
-  'SoT/90': '유효슈팅',
+  'ShotsOnTarget/90': '유효슈팅',
   'Passes/90': '패스',
-  'KP/90': '키패스',
+  'KeyPass/90': '키패스',
   Interceptions: '인터셉트',
-  'Aerials/90': '공중볼',
-  GA: '실점',
+  'AerialsWon/90': '공중볼',
+  GoalsConceded: '실점',
   Saves: '선방',
 }
 
@@ -17,19 +17,16 @@ export function getStatLabel(field: string): string {
 }
 
 export const HISTORY_STAT_LABEL_MAP: Record<string, string> = {
-  Goals: '골',
-  Assists: '도움',
-  SoT: '유효슈팅',
-  'Key Passes': '키패스',
-  Passes: '패스',
-  'Pass%': '패스 정확도',
-  Tackles: '태클',
-  Interceptions: '인터셉트',
-  Clearances: '클리어',
-  'Aerials Won': '공중볼 경합',
-  Saves: '선방',
-  GA: '실점',
-  'Clean Sheets': '클린시트',
+  'Goals/90': '득점',
+  'Shots/90': '슈팅',
+  'SuccessfulDribbles/90': '드리블 성공',
+  'KeyPass/90': '키패스',
+  'Passes/90': '패스',
+  'Tackles/90': '태클',
+  'AerialsWon/90': '공중볼 경합',
+  'Blocks/90': '블록',
+  PassAccuracy: '패스 정확도',
+  CleanSheets: '클린시트',
 }
 
 export function getHistoryStatLabel(label: string): string {
@@ -75,7 +72,7 @@ export function formatGrowthPercent(value: number): string {
 
 export function formatStatValue(label: string, value: number | null): string {
   if (value === null) return '—'
-  if (label === 'Pass%') return `${value.toFixed(1)}%`
+  if (label === 'PassAccuracy') return `${value.toFixed(1)}%`
   return Math.round(value).toLocaleString('en-US')
 }
 

--- a/src/widgets/player-history/ui/SeasonStatsCharts.tsx
+++ b/src/widgets/player-history/ui/SeasonStatsCharts.tsx
@@ -53,7 +53,7 @@ function formatTooltipValue(
 ): string {
   if (value == null || !Number.isFinite(value)) return '-'
   if (dataKey === 'rating') return value.toFixed(1)
-  if (dataKey === 'pass_') return `${value.toFixed(1)}%`
+  if (dataKey === 'passaccuracy') return `${value.toFixed(1)}%`
   return Math.round(value).toLocaleString('en-US')
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #24 

## 📝작업 내용

프론트 매핑 테이블의 키가 백엔드 실제 응답 라벨과 달라 지표가 영어로 노출되고 히스토리 그래프가 렌더링되지 않던 문제 수정

- `STAT_LABEL_MAP` (검색/상세 카드) 키를 백엔드 실제 라벨로 정렬(`ShotsOnTarget/90`·`KeyPass/90`·`AerialsWon/90`·`GoalsConceded`)
- `HISTORY_STAT_LABEL_MAP` / `HISTORY_STAT_COLOR_MAP` 키를 히스토리 응답 라벨로 정렬
- `STAT_GROUPS_BY_POSITION`을 포지션별 실제 지표로 재구성 (스케일 차이 큰 `Passes/90`·`PassAccuracy`는 별도 차트로 분리)

### 스크린샷 (선택)
<img width="1942" height="1024" alt="image" src="https://github.com/user-attachments/assets/2bcbd49a-6d1c-48c3-b0e7-6935daee26ea" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
